### PR TITLE
fix: padding starting after ticks for vertical charts

### DIFF
--- a/src/plugin/hierarchical.ts
+++ b/src/plugin/hierarchical.ts
@@ -242,7 +242,7 @@ function zoomOut(chart: IEnhancedChart, parent: ILabelNode) {
 
 function resolveElement(event: { x: number; y: number }, scale: HierarchicalScale) {
   const hor = scale.isHorizontal();
-  const offset = hor ? scale.top + scale.options.padding : scale.left - scale.options.padding;
+  const offset = hor ? scale.bottom + scale.options.padding : scale.left - scale.options.padding;
   if ((hor && event.y <= offset) || (!hor && event.x > offset)) {
     return null;
   }
@@ -547,7 +547,7 @@ const hierarchicalPlugin: Plugin = {
     if (hor) {
       ctx.textAlign = 'center';
       ctx.textBaseline = renderLabel === 'above' ? 'bottom' : 'top';
-      ctx.translate(scale.left, scale.top + scale.options.padding);
+      ctx.translate(scale.left, scale.bottom + scale.options.padding);
       roots.forEach((n) => preOrderTraversal(n, renderHorLevel));
     } else {
       ctx.textAlign = 'right';

--- a/src/scale/hierarchical.ts
+++ b/src/scale/hierarchical.ts
@@ -12,7 +12,7 @@ export interface IHierarchicalScaleOptions extends CategoryScaleOptions {
   levelPercentage: number;
   /**
    * padding of the first collapse to the start of the x-axis
-   * @default 25
+   * @default 5
    */
   padding: number;
   /**
@@ -89,7 +89,7 @@ const defaultConfig: Partial<Omit<IHierarchicalScaleOptions, 'grid'>> & {
   /**
    * top/left padding for showing the hierarchy marker
    */
-  padding: 25,
+  padding: 5,
   /**
    * position of the hierarchy label
    * possible values: 'below', 'above', null to disable


### PR DESCRIPTION
Fixing the overlapping we have with ticks with large text.

See how it's looking now:

Without focus
![image](https://user-images.githubusercontent.com/39319636/233171291-f8e2ffe7-a415-4d0c-9c49-f2fd3b8f7859.png)


Focusing
![image](https://user-images.githubusercontent.com/39319636/233171411-65c7ed26-1eca-4b1f-bfe6-4e723f509489.png)

